### PR TITLE
Fixed prepare key

### DIFF
--- a/comiclist.coffee
+++ b/comiclist.coffee
@@ -26,9 +26,7 @@ get_url = (puplisher, obj) ->
   url = url_source[puplisher]+url_source.search
   return url.format obj
 
-prepare_key = (key) ->
-  key.replace ' ', '+'
-  return '"'+key+'"'
+prepare_key = (key) -> '"' + (key.replace /\s+/g, '+') + '"'
 
 get_results = (robot, puplisher, search_options, cb) ->
   robot.http(get_url(puplisher, search_options)).get() (err, res, body) ->


### PR DESCRIPTION
string.replace does not replace in-place but returns the new string. But it also replaces only one instance of the sub-string that is to be replaced.

The new version replaces all occurrences of spaces with pluses and multiple subsequent spaces are only replaced by one plus.
